### PR TITLE
Replace fmt.Sprintf with equivalent strconv.Itoa

### DIFF
--- a/command/changetype_test.go
+++ b/command/changetype_test.go
@@ -1,117 +1,118 @@
 package command
 
 import (
-    "github.com/stretchr/testify/assert"
-    "testing"
-    "time"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestNoExpireChange(t *testing.T){
-    key := "string_key"
-    args := []string{key, "10"}
+func TestNoExpireChange(t *testing.T) {
+	key := "string_key"
+	args := []string{key, "10"}
 
-    ctx := ContextTest("set", args...)
-    Call(ctx)
-    assert.Contains(t, ctxString(ctx.Out), "OK")
-    EqualGet(t, key, "10", nil)
+	ctx := ContextTest("set", args...)
+	Call(ctx)
+	assert.Contains(t, ctxString(ctx.Out), "OK")
+	EqualGet(t, key, "10", nil)
 
-    args = []string{key, "a", "b", "c"}
-    ctx1 := ContextTest("sadd", args...)
-    Call(ctx1)
-    assert.Contains(t, ctxString(ctx1.Out), "WRONGTYPE")
+	args = []string{key, "a", "b", "c"}
+	ctx1 := ContextTest("sadd", args...)
+	Call(ctx1)
+	assert.Contains(t, ctxString(ctx1.Out), "WRONGTYPE")
 
-    args = []string{key}
-    ctx2 := ContextTest("scard", args...)
-    Call(ctx2)
-    assert.Contains(t, ctxString(ctx2.Out), "WRONGTYPE")
+	args = []string{key}
+	ctx2 := ContextTest("scard", args...)
+	Call(ctx2)
+	assert.Contains(t, ctxString(ctx2.Out), "WRONGTYPE")
 
-    args = []string{key, "1", "a"}
-    ctx3 := ContextTest("zadd", args...)
-    Call(ctx3)
-    assert.Contains(t, ctxString(ctx3.Out), "WRONGTYPE")
+	args = []string{key, "1", "a"}
+	ctx3 := ContextTest("zadd", args...)
+	Call(ctx3)
+	assert.Contains(t, ctxString(ctx3.Out), "WRONGTYPE")
 }
-func TestExpireChange(t *testing.T){
+func TestExpireChange(t *testing.T) {
 
-    Cfg.Expire.Disable = true
-    Cfg.GC.Disable = true
-    time.Sleep(time.Second)
+	Cfg.Expire.Disable = true
+	Cfg.GC.Disable = true
+	time.Sleep(time.Second)
 
-    key := "string_key"
-    args := []string{key, "10", "ex", "4"}
+	key := "string_key"
+	args := []string{key, "10", "ex", "4"}
 
-    ctx := ContextTest("set", args...)
-    Call(ctx)
-    assert.Contains(t, ctxString(ctx.Out), "OK")
+	ctx := ContextTest("set", args...)
+	Call(ctx)
+	assert.Contains(t, ctxString(ctx.Out), "OK")
 
-    args = []string{key, "a", "b", "c"}
-    ctx1 := ContextTest("sadd", args...)
-    Call(ctx1)
-    assert.Contains(t, ctxString(ctx1.Out), "WRONGTYPE")
+	args = []string{key, "a", "b", "c"}
+	ctx1 := ContextTest("sadd", args...)
+	Call(ctx1)
+	assert.Contains(t, ctxString(ctx1.Out), "WRONGTYPE")
 
-    time.Sleep(time.Second * 4)
+	time.Sleep(time.Second * 4)
 
-    args = []string{key, "a", "b", "c"}
-    ctx2 := ContextTest("sadd", args...)
-    Call(ctx2)
-    assert.Contains(t, ctxString(ctx2.Out), "3")
+	args = []string{key, "a", "b", "c"}
+	ctx2 := ContextTest("sadd", args...)
+	Call(ctx2)
+	assert.Contains(t, ctxString(ctx2.Out), "3")
 
-    args = []string{key, "4"}
-    ctx = ContextTest("expire", args...)
-    Call(ctx)
-    assert.Contains(t, ctxString(ctx.Out), "1")
+	args = []string{key, "4"}
+	ctx = ContextTest("expire", args...)
+	Call(ctx)
+	assert.Contains(t, ctxString(ctx.Out), "1")
 
-    args = []string{key, "1", "a"}
-    ctx = ContextTest("zadd", args...)
-    Call(ctx)
-    assert.Contains(t, ctxString(ctx.Out), "WRONGTYPE")
+	args = []string{key, "1", "a"}
+	ctx = ContextTest("zadd", args...)
+	Call(ctx)
+	assert.Contains(t, ctxString(ctx.Out), "WRONGTYPE")
 
-    time.Sleep(time.Second * 4)
+	time.Sleep(time.Second * 4)
 
-    args = []string{key, "1", "a"}
-    ctx = ContextTest("zadd", args...)
-    Call(ctx)
-    assert.Contains(t, ctxString(ctx.Out), "1")
+	args = []string{key, "1", "a"}
+	ctx = ContextTest("zadd", args...)
+	Call(ctx)
+	assert.Contains(t, ctxString(ctx.Out), "1")
 
-    args = []string{key, "4"}
-    ctx = ContextTest("expire", args...)
-    Call(ctx)
-    assert.Contains(t, ctxString(ctx.Out), "1")
+	args = []string{key, "4"}
+	ctx = ContextTest("expire", args...)
+	Call(ctx)
+	assert.Contains(t, ctxString(ctx.Out), "1")
 
-    args = []string{key, "a", "1"}
-    ctx = ContextTest("hset", args...)
-    Call(ctx)
-    assert.Contains(t, ctxString(ctx.Out), "WRONGTYPE")
+	args = []string{key, "a", "1"}
+	ctx = ContextTest("hset", args...)
+	Call(ctx)
+	assert.Contains(t, ctxString(ctx.Out), "WRONGTYPE")
 
-    time.Sleep(time.Second * 4)
+	time.Sleep(time.Second * 4)
 
-    args = []string{key, "0", "2"}
-    ctx = ContextTest("zrange", args...)
-    Call(ctx)
-    assert.Contains(t, ctxString(ctx.Out), "0")
+	args = []string{key, "0", "2"}
+	ctx = ContextTest("zrange", args...)
+	Call(ctx)
+	assert.Contains(t, ctxString(ctx.Out), "0")
 
-    args = []string{key, "1", "a"}
-    ctx = ContextTest("hset", args...)
-    Call(ctx)
-    assert.Contains(t, ctxString(ctx.Out), "1")
+	args = []string{key, "1", "a"}
+	ctx = ContextTest("hset", args...)
+	Call(ctx)
+	assert.Contains(t, ctxString(ctx.Out), "1")
 
-    args = []string{key, "4"}
-    ctx = ContextTest("expire", args...)
-    Call(ctx)
-    assert.Contains(t, ctxString(ctx.Out), "1")
+	args = []string{key, "4"}
+	ctx = ContextTest("expire", args...)
+	Call(ctx)
+	assert.Contains(t, ctxString(ctx.Out), "1")
 
-    args = []string{key, "a"}
-    ctx = ContextTest("lpush", args...)
-    Call(ctx)
-    assert.Contains(t, ctxString(ctx.Out), "WRONGTYPE")
+	args = []string{key, "a"}
+	ctx = ContextTest("lpush", args...)
+	Call(ctx)
+	assert.Contains(t, ctxString(ctx.Out), "WRONGTYPE")
 
-    time.Sleep(time.Second * 4)
+	time.Sleep(time.Second * 4)
 
-    args = []string{key, "a"}
-    ctx = ContextTest("lpush", args...)
-    Call(ctx)
-    assert.Contains(t, ctxString(ctx.Out), "1")
+	args = []string{key, "a"}
+	ctx = ContextTest("lpush", args...)
+	Call(ctx)
+	assert.Contains(t, ctxString(ctx.Out), "1")
 
-    Cfg.Expire.Disable = false
-    Cfg.GC.Disable = false
-    time.Sleep(time.Second)
+	Cfg.Expire.Disable = false
+	Cfg.GC.Disable = false
+	time.Sleep(time.Second)
 }

--- a/command/extension.go
+++ b/command/extension.go
@@ -2,10 +2,11 @@ package command
 
 import (
 	"fmt"
-	"github.com/distributedio/titan/db"
-	"github.com/distributedio/titan/encoding/resp"
 	"math"
 	"strconv"
+
+	"github.com/distributedio/titan/db"
+	"github.com/distributedio/titan/encoding/resp"
 )
 
 // Escan scan the expiration list
@@ -50,7 +51,7 @@ func Escan(ctx *Context, txn *db.Transaction) (OnCommit, error) {
 		return BytesArray(ctx.Out, nil), nil
 	}
 	// set the last ts as cursor
-	cursor := fmt.Sprintf("%d", at[n-1])
+	cursor := strconv.Itoa(at[n-1])
 
 	// set cursor to 0 if there is no more results
 	if int64(n) < count {

--- a/db/set_test.go
+++ b/db/set_test.go
@@ -536,27 +536,26 @@ func TestRemoveRepByMap(t *testing.T) {
 		want [][]byte
 	}{
 		{
-			name:  "single member",
-			args:  args{
-				members : [][]byte{[]byte("value1")},
+			name: "single member",
+			args: args{
+				members: [][]byte{[]byte("value1")},
 			},
-			want:  [][]byte{[]byte("value1")},
+			want: [][]byte{[]byte("value1")},
 		},
 		{
-			name:  "multi members",
-			args:  args{
-				members : [][]byte{[]byte("value1"),[]byte("value2"),[]byte("value3")},
+			name: "multi members",
+			args: args{
+				members: [][]byte{[]byte("value1"), []byte("value2"), []byte("value3")},
 			},
-			want:  [][]byte{[]byte("value1"),[]byte("value2"),[]byte("value3")},
+			want: [][]byte{[]byte("value1"), []byte("value2"), []byte("value3")},
 		},
 		{
-			name:  "with duplicate members",
-			args:  args{
-				members : [][]byte{[]byte("value1"),[]byte("value2"),[]byte("value1")},
+			name: "with duplicate members",
+			args: args{
+				members: [][]byte{[]byte("value1"), []byte("value2"), []byte("value1")},
 			},
-			want:  [][]byte{[]byte("value1"),[]byte("value2")},
+			want: [][]byte{[]byte("value1"), []byte("value2")},
 		},
-
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/db/util.go
+++ b/db/util.go
@@ -5,8 +5,6 @@ import (
 	"math"
 	"math/bits"
 	"time"
-
-	"github.com/satori/go.uuid"
 )
 
 // UUID allocates an unique object ID.

--- a/db/zlistproto/zlist.pb.go
+++ b/db/zlistproto/zlist.pb.go
@@ -13,11 +13,15 @@ It has these top-level messages:
 */
 package zlistproto
 
-import proto "github.com/golang/protobuf/proto"
-import fmt "fmt"
-import math "math"
+import (
+	fmt "fmt"
 
-import io "io"
+	proto "github.com/golang/protobuf/proto"
+
+	math "math"
+
+	io "io"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal


### PR DESCRIPTION
This batch change replaces `fmt.Sprintf` with `strconv.Itoa`

[_Created by Sourcegraph batch change `elzanne.wentzel/sprintf-to-itoa`._](https://demo.sourcegraph.com/users/elzanne.wentzel/batch-changes/sprintf-to-itoa)