### PR TITLE
Go 1.18: rewrite `interface{}` to `any`

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -261,7 +261,7 @@ func AutoCommit(cmd TxnCommand) Command {
 }
 
 func feedMonitors(ctx *Context) {
-	ctx.Server.Monitors.Range(func(k, v interface{}) bool {
+	ctx.Server.Monitors.Range(func(k, v any) bool {
 		mCtx := v.(*Context)
 		if mCtx.Client.Namespace != sysAdminNamespace && mCtx.Client.Namespace != ctx.Client.Namespace {
 			return true

--- a/command/server.go
+++ b/command/server.go
@@ -29,7 +29,7 @@ func Client(ctx *Context) {
 		now := time.Now()
 		var lines []string
 		clients := &ctx.Server.Clients
-		clients.Range(func(k, v interface{}) bool {
+		clients.Range(func(k, v any) bool {
 			client := v.(*context.ClientContext)
 			if ctx.Client.Namespace != sysAdminNamespace && client.Namespace != ctx.Client.Namespace {
 				return true
@@ -145,7 +145,7 @@ func Client(ctx *Context) {
 		// now kill clients with above rules
 		killed := 0
 		closeSelf := false
-		ctx.Server.Clients.Range(func(k, v interface{}) bool {
+		ctx.Server.Clients.Range(func(k, v any) bool {
 			cli := v.(*context.ClientContext)
 
 			if cli.Namespace != sysAdminNamespace && cli.Namespace != ctx.Client.Namespace {
@@ -366,7 +366,7 @@ func Info(ctx *Context) {
 
 	// count the number of clients
 	var numberOfClients int
-	ctx.Server.Clients.Range(func(k, v interface{}) bool {
+	ctx.Server.Clients.Range(func(k, v any) bool {
 		numberOfClients++
 		return true
 	})

--- a/command/sets.go
+++ b/command/sets.go
@@ -206,12 +206,12 @@ type MinHeap []*db.SetIter
 func (h MinHeap) Len() int           { return len(h) }
 func (h MinHeap) Less(i, j int) bool { return bytes.Compare(h[i].Value(), h[j].Value()) < 0 }
 func (h MinHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
-func (h *MinHeap) Push(x interface{}) {
+func (h *MinHeap) Push(x any) {
 	item := x.(*db.SetIter)
 	*h = append(*h, item)
 }
 
-func (h *MinHeap) Pop() interface{} {
+func (h *MinHeap) Pop() any {
 	old := *h
 	n := len(old)
 	item := old[n-1]

--- a/context/context.go
+++ b/context/context.go
@@ -122,7 +122,7 @@ func WithTimeout(parent *Context, timeout time.Duration) (*Context, CancelFunc) 
 }
 
 // WithValue returns a copy of parent in which the value associated with key is val.
-func WithValue(parent *Context, key, val interface{}) *Context {
+func WithValue(parent *Context, key, val any) *Context {
 	ctx := *parent
 	ctx.Context = context.WithValue(parent.Context, key, val)
 	return &ctx

--- a/db/store/store.go
+++ b/db/store/store.go
@@ -42,7 +42,7 @@ const (
 	PriorityHigh
 )
 
-//type rename tidb kv type
+// type rename tidb kv type
 type (
 	// Storage defines the interface for storage.
 	Storage kv.Storage
@@ -54,7 +54,7 @@ type (
 	Option kv.Option
 )
 
-//Open create tikv db ,create fake db if addr contains mockaddr
+// Open create tikv db ,create fake db if addr contains mockaddr
 func Open(addrs string) (r Storage, e error) {
 	if strings.Contains(addrs, MockAddr) {
 		return MockOpen(addrs)
@@ -96,7 +96,7 @@ func BatchGetValues(txn Transaction, keys [][]byte) (map[string][]byte, error) {
 	return txn.BatchGet(kvkeys)
 }
 
-func SetOption(txn Transaction, opt Option, val interface{}) {
+func SetOption(txn Transaction, opt Option, val any) {
 	txn.SetOption(kv.Option(opt), val)
 }
 

--- a/tools/autotest/cmd/key.go
+++ b/tools/autotest/cmd/key.go
@@ -7,21 +7,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//ExampleKey verify the key command
+// ExampleKey verify the key command
 type ExampleKey struct {
 	conn redis.Conn
 }
 
-//NewExampleKey create key object
+// NewExampleKey create key object
 func NewExampleKey(conn redis.Conn) *ExampleKey {
 	return &ExampleKey{
 		conn: conn,
 	}
 }
 
-//DelEqual verify that the return value of the del key operation is correct
+// DelEqual verify that the return value of the del key operation is correct
 func (ek *ExampleKey) DelEqual(t *testing.T, expectReply int, keys ...string) {
-	req := make([]interface{}, len(keys))
+	req := make([]any, len(keys))
 	for i, eky := range keys {
 		req[i] = eky
 	}
@@ -30,15 +30,15 @@ func (ek *ExampleKey) DelEqual(t *testing.T, expectReply int, keys ...string) {
 	assert.NoError(t, err)
 }
 
-//DelEqualErr verify that the return error value of the del key operation is correct
-func (ek *ExampleKey) DelEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// DelEqualErr verify that the return error value of the del key operation is correct
+func (ek *ExampleKey) DelEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := ek.conn.Do("del", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-//ExistsEqual verify that the return value of the exists key operation is correct
+// ExistsEqual verify that the return value of the exists key operation is correct
 func (ek *ExampleKey) ExistsEqual(t *testing.T, expectReply int, keys ...string) {
-	req := make([]interface{}, len(keys))
+	req := make([]any, len(keys))
 	for i, eky := range keys {
 		req[i] = eky
 	}
@@ -47,53 +47,53 @@ func (ek *ExampleKey) ExistsEqual(t *testing.T, expectReply int, keys ...string)
 	assert.NoError(t, err)
 }
 
-//ExistsEqualErr verify that the return error value of the exists key operation is correct
-func (ek *ExampleKey) ExistsEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// ExistsEqualErr verify that the return error value of the exists key operation is correct
+func (ek *ExampleKey) ExistsEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := ek.conn.Do("exists", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-//TTLEqual verify that the return value of the ttl key operation is correct
+// TTLEqual verify that the return value of the ttl key operation is correct
 func (ek *ExampleKey) TTLEqual(t *testing.T, key string, expectReply int) {
 	reply, err := redis.Int(ek.conn.Do("ttl", key))
 	assert.Equal(t, expectReply, reply)
 	assert.NoError(t, err)
 }
 
-//TTLEqualErr verify that the return error value of the ttl key operation is correct
-func (ek *ExampleKey) TTLEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// TTLEqualErr verify that the return error value of the ttl key operation is correct
+func (ek *ExampleKey) TTLEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := ek.conn.Do("ttl", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-//PTTLEqual verify that the return value of the ttl key operation is correct
+// PTTLEqual verify that the return value of the ttl key operation is correct
 func (ek *ExampleKey) PTTLEqual(t *testing.T, key string, expectReply int) {
 	reply, err := redis.Int(ek.conn.Do("ttl", key))
 	assert.Equal(t, expectReply, reply)
 	assert.NoError(t, err)
 }
 
-//PTTLEqualErr verify that the return error value of the ttl key operation is correct
-func (ek *ExampleKey) PTTLEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// PTTLEqualErr verify that the return error value of the ttl key operation is correct
+func (ek *ExampleKey) PTTLEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := ek.conn.Do("ttl", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-//Info TODO
-func (ek *ExampleKey) Info(t *testing.T, key string, expectReply interface{}) {
+// Info TODO
+func (ek *ExampleKey) Info(t *testing.T, key string, expectReply any) {
 
 }
 
-//InfoEqualErr TODO
-func (ek *ExampleKey) InfoEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// InfoEqualErr TODO
+func (ek *ExampleKey) InfoEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := ek.conn.Do("info", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-//ScanEqual verify that the return value of the scan key operation is correct
-//default scan all key in store
+// ScanEqual verify that the return value of the scan key operation is correct
+// default scan all key in store
 func (ek *ExampleKey) ScanEqual(t *testing.T, match string, expectCount int) {
-	var reply interface{}
+	var reply any
 	var err error
 	if match == "" {
 		reply, err = ek.conn.Do("Scan", 0, "count", 10000)
@@ -106,115 +106,115 @@ func (ek *ExampleKey) ScanEqual(t *testing.T, match string, expectCount int) {
 	assert.NoError(t, err)
 }
 
-//ScanEqualErr verify that the return err value of the scan key operation is correct
-func (ek *ExampleKey) ScanEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// ScanEqualErr verify that the return err value of the scan key operation is correct
+func (ek *ExampleKey) ScanEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := ek.conn.Do("scan", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-//RandomKeyEqual verify that the return value of the random key operation is correct
+// RandomKeyEqual verify that the return value of the random key operation is correct
 func (ek *ExampleKey) RandomKeyEqual(t *testing.T) {
 	_, err := ek.conn.Do("RANDOMKEY")
 	assert.NoError(t, err)
 }
 
-//RandomKeyEqualErr verify that the return err value of the random key operation is correct
-func (ek *ExampleKey) RandomKeyEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// RandomKeyEqualErr verify that the return err value of the random key operation is correct
+func (ek *ExampleKey) RandomKeyEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := ek.conn.Do("Randomkey", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-//ExpireEqual verify that the return value of the expire key operation is correct
+// ExpireEqual verify that the return value of the expire key operation is correct
 func (ek *ExampleKey) ExpireEqual(t *testing.T, key string, value, expectValue int) {
 	reply, err := redis.Int(ek.conn.Do("expire", key, value))
 	assert.NoError(t, err)
 	assert.Equal(t, expectValue, reply)
 }
 
-//ExpireEqualErr verify that the err return value of the expire key operation is correct
-func (ek *ExampleKey) ExpireEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// ExpireEqualErr verify that the err return value of the expire key operation is correct
+func (ek *ExampleKey) ExpireEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := ek.conn.Do("expire", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-//ExpireAtEqual verify that the return value of the expire key operation is correct
+// ExpireAtEqual verify that the return value of the expire key operation is correct
 func (ek *ExampleKey) ExpireAtEqual(t *testing.T, key string, value, expectValue int) {
 	reply, err := redis.Int(ek.conn.Do("expireat", key, value))
 	assert.NoError(t, err)
 	assert.Equal(t, expectValue, reply)
 }
 
-//AtExpireEqualErr verify that the err return value of the expire key operation is correct
-func (ek *ExampleKey) ExpireAtEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// AtExpireEqualErr verify that the err return value of the expire key operation is correct
+func (ek *ExampleKey) ExpireAtEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := ek.conn.Do("expireat", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-//PExpireEqual verify that the return value of the expire key operation is correct
+// PExpireEqual verify that the return value of the expire key operation is correct
 func (ek *ExampleKey) PExpireEqual(t *testing.T, key string, value, expectValue int) {
 	reply, err := redis.Int(ek.conn.Do("pexpire", key, value))
 	assert.NoError(t, err)
 	assert.Equal(t, expectValue, reply)
 }
 
-//PExpireEqualErr verify that the err return value of the expire key operation is correct
-func (ek *ExampleKey) PExpireEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// PExpireEqualErr verify that the err return value of the expire key operation is correct
+func (ek *ExampleKey) PExpireEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := ek.conn.Do("pexpire", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-//ExpireAtEqual verify that the return value of the expire key operation is correct
+// ExpireAtEqual verify that the return value of the expire key operation is correct
 func (ek *ExampleKey) PExpireAtEqual(t *testing.T, key string, value, expectValue int) {
 	reply, err := redis.Int(ek.conn.Do("pexpireat", key, value))
 	assert.NoError(t, err)
 	assert.Equal(t, expectValue, reply)
 }
 
-//PExpireEqualAtErr verify that the err return value of the expire key operation is correct
-func (ek *ExampleKey) PExpireAtEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// PExpireEqualAtErr verify that the err return value of the expire key operation is correct
+func (ek *ExampleKey) PExpireAtEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := ek.conn.Do("pexpireat", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-func (ek *ExampleKey) TypeEqual(t *testing.T, key string, expectValue interface{}) {
+func (ek *ExampleKey) TypeEqual(t *testing.T, key string, expectValue any) {
 	reply, err := redis.String(ek.conn.Do("type", key))
 	assert.NoError(t, err)
 	assert.Equal(t, expectValue, reply)
 }
 
-func (ek *ExampleKey) TypeEqualErr(t *testing.T, errValue string, args ...interface{}) {
+func (ek *ExampleKey) TypeEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := redis.String(ek.conn.Do("type", args...))
 	assert.EqualError(t, err, errValue)
 }
 
-func (ek *ExampleKey) KeysEqual(t *testing.T, key string, expectValue interface{}) {
+func (ek *ExampleKey) KeysEqual(t *testing.T, key string, expectValue any) {
 }
 
-func (ek *ExampleKey) KeysEqualErr(t *testing.T, errValue string, expectValue interface{}) {
+func (ek *ExampleKey) KeysEqualErr(t *testing.T, errValue string, expectValue any) {
 }
 
-func (ek *ExampleKey) ObjectEqual(t *testing.T, key string, expectValue interface{}) {
+func (ek *ExampleKey) ObjectEqual(t *testing.T, key string, expectValue any) {
 	reply, err := redis.String(ek.conn.Do("object", "encoding", key))
 	assert.NoError(t, err)
 	assert.Equal(t, expectValue, reply)
 }
 
-func (ek *ExampleKey) ObjectEqualErr(t *testing.T, errValue string, args ...interface{}) {
-	tmp := []interface{}{"encoding"}
+func (ek *ExampleKey) ObjectEqualErr(t *testing.T, errValue string, args ...any) {
+	tmp := []any{"encoding"}
 	tmp = append(tmp, args...)
 	_, err := redis.String(ek.conn.Do("object", tmp...))
 	assert.EqualError(t, err, errValue)
 }
 
-//Persist verify that the return value of the expire key operation is correct
+// Persist verify that the return value of the expire key operation is correct
 func (ek *ExampleKey) PersistEqual(t *testing.T, key string, expectValue int) {
 	reply, err := redis.Int(ek.conn.Do("persist", key))
 	assert.NoError(t, err)
 	assert.Equal(t, expectValue, reply)
 }
 
-//PersistEqualAtErr verify that the err return value of the expire key operation is correct
-func (ek *ExampleKey) PersistEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// PersistEqualAtErr verify that the err return value of the expire key operation is correct
+func (ek *ExampleKey) PersistEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := ek.conn.Do("persist", args...)
 	assert.EqualError(t, err, errValue)
 }

--- a/tools/autotest/cmd/list.go
+++ b/tools/autotest/cmd/list.go
@@ -7,14 +7,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//ExampleList the key command
-//mapList record the key and value of the operation
+// ExampleList the key command
+// mapList record the key and value of the operation
 type ExampleList struct {
 	mapList map[string][]string
 	conn    redis.Conn
 }
 
-//NewExampleList create list object
+// NewExampleList create list object
 func NewExampleList(conn redis.Conn) *ExampleList {
 	return &ExampleList{
 		conn:    conn,
@@ -22,7 +22,7 @@ func NewExampleList(conn redis.Conn) *ExampleList {
 	}
 }
 
-//LsetEqual verify that the return value of the lset key operation is correct
+// LsetEqual verify that the return value of the lset key operation is correct
 func (el *ExampleList) LsetEqual(t *testing.T, key string, index int, value string) {
 	if _, ok := el.mapList[key]; !ok {
 		el.mapList[key] = make([]string, 0, 10)
@@ -40,15 +40,15 @@ func (el *ExampleList) LsetEqual(t *testing.T, key string, index int, value stri
 	assert.Nil(t, err)
 }
 
-//LsetEqualErr verify that the return err value of the Lset key operation is correct
-func (el *ExampleList) LsetEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// LsetEqualErr verify that the return err value of the Lset key operation is correct
+func (el *ExampleList) LsetEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := el.conn.Do("lset", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-//LpushEqual verify that the return err value of the lpush key operation is correct
+// LpushEqual verify that the return err value of the lpush key operation is correct
 func (el *ExampleList) LpushEqual(t *testing.T, key string, values ...string) {
-	req := make([]interface{}, 0, len(values))
+	req := make([]any, 0, len(values))
 	tmp := make([]string, 0, len(values))
 	if _, ok := el.mapList[key]; !ok {
 		el.mapList[key] = make([]string, 0, 0)
@@ -68,13 +68,13 @@ func (el *ExampleList) LpushEqual(t *testing.T, key string, values ...string) {
 	assert.Nil(t, err)
 }
 
-//LpushEqualErr verify that the return err value of the Lpush key operation is correct
-func (el *ExampleList) LpushEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// LpushEqualErr verify that the return err value of the Lpush key operation is correct
+func (el *ExampleList) LpushEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := el.conn.Do("lpush", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-//LpopEqual verify that the return err value of the Lpop key operation is correct
+// LpopEqual verify that the return err value of the Lpop key operation is correct
 func (el *ExampleList) LpopEqual(t *testing.T, key string) {
 	if vs, ok := el.mapList[key]; ok {
 		v := vs[0]
@@ -89,13 +89,13 @@ func (el *ExampleList) LpopEqual(t *testing.T, key string) {
 	}
 }
 
-//LpopEqualErr verify that the return err value of the Lpop key operation is correct
-func (el *ExampleList) LpopEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// LpopEqualErr verify that the return err value of the Lpop key operation is correct
+func (el *ExampleList) LpopEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := el.conn.Do("lpop", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-//LindexEqual verify that the return err value of the Lindex key operation is correct
+// LindexEqual verify that the return err value of the Lindex key operation is correct
 func (el *ExampleList) LindexEqual(t *testing.T, key string, index int) {
 	if index <= 0 {
 		index = -index
@@ -113,13 +113,13 @@ func (el *ExampleList) LindexEqual(t *testing.T, key string, index int) {
 	}
 }
 
-//LindexEqualErr verify that the return err value of the Lindex key operation is correct
-func (el *ExampleList) LindexEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// LindexEqualErr verify that the return err value of the Lindex key operation is correct
+func (el *ExampleList) LindexEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := el.conn.Do("lindex", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-//LrangeEqual verify that the return value of the Lrange key operation is correct
+// LrangeEqual verify that the return value of the Lrange key operation is correct
 func (el *ExampleList) LrangeEqual(t *testing.T, key string, start, end int) {
 	if start > len(el.mapList[key]) {
 		reply, err := redis.Strings(el.conn.Do("lrange", key, start, end))
@@ -148,15 +148,15 @@ func (el *ExampleList) LrangeEqual(t *testing.T, key string, start, end int) {
 	assert.Nil(t, err)
 }
 
-//LrangeEqualErr verify that the return err value of the lrange key operation is correct
-func (el *ExampleList) LrangeEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// LrangeEqualErr verify that the return err value of the lrange key operation is correct
+func (el *ExampleList) LrangeEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := el.conn.Do("lrange", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-//RpushEqual verify that the return value of the Rpush key operation is correct
+// RpushEqual verify that the return value of the Rpush key operation is correct
 func (el *ExampleList) RpushEqual(t *testing.T, key string, values []string) {
-	req := make([]interface{}, 0, len(values))
+	req := make([]any, 0, len(values))
 	req = append(req, key)
 	if _, ok := el.mapList[key]; !ok {
 		el.mapList[key] = make([]string, 0, 0)
@@ -170,13 +170,13 @@ func (el *ExampleList) RpushEqual(t *testing.T, key string, values []string) {
 	assert.Nil(t, err)
 }
 
-//RpushEqualErr verify that the return err value of the Rpush key operation is correct
-func (el *ExampleList) RpushEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// RpushEqualErr verify that the return err value of the Rpush key operation is correct
+func (el *ExampleList) RpushEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := el.conn.Do("Rpush", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-//RpopEqual verify that the return value of the rpop key operation is correct
+// RpopEqual verify that the return value of the rpop key operation is correct
 func (el *ExampleList) RpopEqual(t *testing.T, key string) {
 	v := el.mapList[key][len(el.mapList[key])-1]
 	el.mapList[key] = el.mapList[key][:len(el.mapList[key])]
@@ -185,21 +185,21 @@ func (el *ExampleList) RpopEqual(t *testing.T, key string) {
 	assert.Nil(t, err)
 }
 
-//RpopEqualErr verify that the return err value of the rpop key operation is correct
-func (el *ExampleList) RpopEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// RpopEqualErr verify that the return err value of the rpop key operation is correct
+func (el *ExampleList) RpopEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := el.conn.Do("Rpop", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-//LlenEqual verify that the return value of the Llen key operation is correct
+// LlenEqual verify that the return value of the Llen key operation is correct
 func (el *ExampleList) LlenEqual(t *testing.T, key string) {
 	reply, err := redis.Int(el.conn.Do("llen", key))
 	assert.Equal(t, len(el.mapList[key]), reply)
 	assert.Nil(t, err)
 }
 
-//LlenEqualErr verify that the return err value of the Llen key operation is correct
-func (el *ExampleList) LlenEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// LlenEqualErr verify that the return err value of the Llen key operation is correct
+func (el *ExampleList) LlenEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := el.conn.Do("Llen", args...)
 	assert.EqualError(t, err, errValue)
 }

--- a/tools/autotest/cmd/multi.go
+++ b/tools/autotest/cmd/multi.go
@@ -7,48 +7,48 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//ExampleMulti verify the multi command
+// ExampleMulti verify the multi command
 type ExampleMulti struct {
 	conn  redis.Conn
-	value []interface{}
+	value []any
 }
 
-//NewExampleMulti create new multi object
+// NewExampleMulti create new multi object
 func NewExampleMulti(conn redis.Conn) *ExampleMulti {
 	return &ExampleMulti{
 		conn: conn,
 	}
 }
 
-//MultiEqual verify that the return value of the multi operation is correct
+// MultiEqual verify that the return value of the multi operation is correct
 func (ms *ExampleMulti) MultiEqual(t *testing.T) {
 	reply, err := redis.String(ms.conn.Do("multi"))
 	assert.NoError(t, err)
 	assert.Equal(t, "OK", reply)
 }
 
-//MultiEqualErr verify that the return err value of the multi operation is correct
-func (ms *ExampleMulti) MultiEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// MultiEqualErr verify that the return err value of the multi operation is correct
+func (ms *ExampleMulti) MultiEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := ms.conn.Do("multi", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-//ExecEqual verify that the return err value of the exec operation is correct
+// ExecEqual verify that the return err value of the exec operation is correct
 func (ms *ExampleMulti) ExecEqual(t *testing.T) {
 	reply, err := redis.MultiBulk(ms.conn.Do("exec"))
 	assert.NoError(t, err)
 	assert.Equal(t, ms.value, reply)
 }
 
-//ExecEqualErr verify that the return err value of the exec operation is correct
-func (ms *ExampleMulti) ExecEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// ExecEqualErr verify that the return err value of the exec operation is correct
+func (ms *ExampleMulti) ExecEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := ms.conn.Do("exec", args...)
 	if errValue != "" {
 		assert.EqualError(t, err, errValue)
 	}
 }
 
-//Cmd analog message sending
+// Cmd analog message sending
 func (ms *ExampleMulti) Cmd(t *testing.T) {
 	reply, err := redis.String(ms.conn.Do("SET", "key-mulit-string", "value"))
 	assert.Equal(t, "QUEUED", reply)

--- a/tools/autotest/cmd/string.go
+++ b/tools/autotest/cmd/string.go
@@ -9,13 +9,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//ExampleString verify the string command
+// ExampleString verify the string command
 type ExampleString struct {
 	values map[string]string
 	conn   redis.Conn
 }
 
-//NewExampleString create new string object
+// NewExampleString create new string object
 func NewExampleString(conn redis.Conn) *ExampleString {
 	return &ExampleString{
 		values: make(map[string]string),
@@ -23,7 +23,7 @@ func NewExampleString(conn redis.Conn) *ExampleString {
 	}
 }
 
-//SetEqual verify that the return value of the set operation is correct
+// SetEqual verify that the return value of the set operation is correct
 func (es *ExampleString) SetEqual(t *testing.T, key string, value string) {
 	es.values[key] = value
 	reply, err := redis.String(es.conn.Do("SET", key, value))
@@ -34,26 +34,26 @@ func (es *ExampleString) SetEqual(t *testing.T, key string, value string) {
 	assert.NoError(t, err)
 }
 
-//GetEqual verify that the return value of the get operation is correct
+// GetEqual verify that the return value of the get operation is correct
 func (es *ExampleString) GetEqual(t *testing.T, key string) {
 	data, err := redis.Bytes(es.conn.Do("GET", key))
 	assert.Equal(t, es.values[key], string(data))
 	assert.NoError(t, err)
 }
 
-//SetEqualErr verify that the return value of the set operation is correct
-func (es *ExampleString) SetEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// SetEqualErr verify that the return value of the set operation is correct
+func (es *ExampleString) SetEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := es.conn.Do("set", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-//GetEqualErr verify that the return value of the set operation is correct
-func (es *ExampleString) GetEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// GetEqualErr verify that the return value of the set operation is correct
+func (es *ExampleString) GetEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := es.conn.Do("get", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-//SetNxEqualErr verify that the return value of the set operation is correct
+// SetNxEqualErr verify that the return value of the set operation is correct
 func (es *ExampleString) SetNxEqual(t *testing.T, key string, value string) {
 	es.values[key] = value
 	reply, err := redis.Int(es.conn.Do("SETNX", key, value))
@@ -64,7 +64,7 @@ func (es *ExampleString) SetNxEqual(t *testing.T, key string, value string) {
 	assert.NoError(t, err)
 }
 
-//SetExEqualErr verify that the return value of the set operation is correct
+// SetExEqualErr verify that the return value of the set operation is correct
 func (es *ExampleString) SetExEqual(t *testing.T, key string, value string, delta int) {
 	es.values[key] = value
 	reply, err := redis.String(es.conn.Do("SETEX", key, delta, value))
@@ -78,7 +78,7 @@ func (es *ExampleString) SetExEqual(t *testing.T, key string, value string, delt
 	assert.Equal(t, "", string(data))
 }
 
-//PSetexEqualErr verify that the return value of the set operation is correct
+// PSetexEqualErr verify that the return value of the set operation is correct
 func (es *ExampleString) PSetexEqual(t *testing.T, key string, value string, delta int) {
 	es.values[key] = value
 	reply, err := redis.String(es.conn.Do("PSETEX", key, delta, value))
@@ -92,13 +92,13 @@ func (es *ExampleString) PSetexEqual(t *testing.T, key string, value string, del
 	assert.Equal(t, "", string(data))
 }
 
-//SetRangeEqualErr verify that the return value of the set operation is correct
+// SetRangeEqualErr verify that the return value of the set operation is correct
 func (es *ExampleString) SetRangeEqual(t *testing.T, key string, value string) {
 }
 
-//MSetNxRangeEqualErr verify that the return value of the set operation is correct
+// MSetNxRangeEqualErr verify that the return value of the set operation is correct
 func (es *ExampleString) MSetNxEqual(t *testing.T, expectValue int, args ...string) {
-	as := make([]interface{}, len(args))
+	as := make([]any, len(args))
 	for i := 0; i < len(args); i = i + 2 {
 		es.values[args[i]] = args[i+1]
 		as[i] = args[i]
@@ -109,7 +109,7 @@ func (es *ExampleString) MSetNxEqual(t *testing.T, expectValue int, args ...stri
 	assert.Equal(t, expectValue, reply)
 }
 
-//AppendEqual verify that the return value of the append operation is correct
+// AppendEqual verify that the return value of the append operation is correct
 func (es *ExampleString) AppendEqual(t *testing.T, key string, value string) {
 	if v, ok := es.values[key]; ok {
 		es.values[key] = v + value
@@ -124,13 +124,13 @@ func (es *ExampleString) AppendEqual(t *testing.T, key string, value string) {
 	assert.NoError(t, err)
 }
 
-//AppendEqualErr TODO
-func (es *ExampleString) AppendEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// AppendEqualErr TODO
+func (es *ExampleString) AppendEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := es.conn.Do("append", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-//IncrEqual verify that the return value of the incr operation is correct
+// IncrEqual verify that the return value of the incr operation is correct
 func (es *ExampleString) IncrEqual(t *testing.T, key string) {
 	var vi int
 	if v, ok := es.values[key]; ok {
@@ -146,7 +146,7 @@ func (es *ExampleString) IncrEqual(t *testing.T, key string) {
 	assert.NoError(t, err)
 }
 
-//DecrEqual verify that the return value of the incr operation is correct
+// DecrEqual verify that the return value of the incr operation is correct
 func (es *ExampleString) DecrEqual(t *testing.T, key string) {
 	var vi int
 	if v, ok := es.values[key]; ok {
@@ -162,7 +162,7 @@ func (es *ExampleString) DecrEqual(t *testing.T, key string) {
 	assert.NoError(t, err)
 }
 
-//IncrByEqual verify that the return value of the incr operation is correct
+// IncrByEqual verify that the return value of the incr operation is correct
 func (es *ExampleString) IncrByEqual(t *testing.T, key string, delta int) {
 	var vi int
 	if v, ok := es.values[key]; ok {
@@ -178,7 +178,7 @@ func (es *ExampleString) IncrByEqual(t *testing.T, key string, delta int) {
 	assert.NoError(t, err)
 }
 
-//IncrByFloatEqual verify that the return value of the incr operation is correct
+// IncrByFloatEqual verify that the return value of the incr operation is correct
 func (es *ExampleString) IncrByFloatEqual(t *testing.T, key string, delta float64) {
 	var vi float64
 	if v, ok := es.values[key]; ok {
@@ -194,7 +194,7 @@ func (es *ExampleString) IncrByFloatEqual(t *testing.T, key string, delta float6
 	assert.NoError(t, err)
 }
 
-//DecrbyEqual verify that the return value of the incr operation is correct
+// DecrbyEqual verify that the return value of the incr operation is correct
 func (es *ExampleString) DecrByEqual(t *testing.T, key string, delta int) {
 	var vi int
 	if v, ok := es.values[key]; ok {
@@ -210,13 +210,13 @@ func (es *ExampleString) DecrByEqual(t *testing.T, key string, delta int) {
 	assert.NoError(t, err)
 }
 
-//IncrEqualErr verify that the return value of the incr operation is correct
-func (es *ExampleString) IncrEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// IncrEqualErr verify that the return value of the incr operation is correct
+func (es *ExampleString) IncrEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := es.conn.Do("incr", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-//StrlenEqual verify that the return value of the strlen operation is correct
+// StrlenEqual verify that the return value of the strlen operation is correct
 func (es *ExampleString) StrlenEqual(t *testing.T, key string) {
 	var vi int
 	if v, ok := es.values[key]; ok {
@@ -229,15 +229,15 @@ func (es *ExampleString) StrlenEqual(t *testing.T, key string) {
 	assert.NoError(t, err)
 }
 
-//StrlenEqualErr verify that the return value of the strlen operation is correct
-func (es *ExampleString) StrlenEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// StrlenEqualErr verify that the return value of the strlen operation is correct
+func (es *ExampleString) StrlenEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := es.conn.Do("strlen", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-//MGetEqual verify that the return value of the mget operation is correct
+// MGetEqual verify that the return value of the mget operation is correct
 func (es *ExampleString) MGetEqual(t *testing.T, args ...string) {
-	as := make([]interface{}, len(args))
+	as := make([]any, len(args))
 	for i, a := range args {
 		as[i] = a
 	}
@@ -252,15 +252,15 @@ func (es *ExampleString) MGetEqual(t *testing.T, args ...string) {
 	}
 }
 
-//MGetEqualErr verify that the return value of the mget operation is correct
-func (es *ExampleString) MGetEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// MGetEqualErr verify that the return value of the mget operation is correct
+func (es *ExampleString) MGetEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := es.conn.Do("Mget", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-//MSetEqual verify that the return value of the mset operation is correct
+// MSetEqual verify that the return value of the mset operation is correct
 func (es *ExampleString) MSetEqual(t *testing.T, args ...string) {
-	as := make([]interface{}, len(args))
+	as := make([]any, len(args))
 	for i := 0; i < len(args); i = i + 2 {
 		es.values[args[i]] = args[i+1]
 		as[i] = args[i]
@@ -275,8 +275,8 @@ func (es *ExampleString) MSetEqual(t *testing.T, args ...string) {
 	}
 }
 
-//MSetEqualErr verify that the return value of the mset operation is correct
-func (es *ExampleString) MSetEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// MSetEqualErr verify that the return value of the mset operation is correct
+func (es *ExampleString) MSetEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := es.conn.Do("Mset", args)
 	assert.EqualError(t, err, errValue)
 }

--- a/tools/autotest/cmd/system.go
+++ b/tools/autotest/cmd/system.go
@@ -7,32 +7,32 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//ExampleSystem verify the system command
+// ExampleSystem verify the system command
 type ExampleSystem struct {
 	conn redis.Conn
 }
 
-//NewExampleSystem create new system object
+// NewExampleSystem create new system object
 func NewExampleSystem(conn redis.Conn) *ExampleSystem {
 	return &ExampleSystem{
 		conn: conn,
 	}
 }
 
-//AuthEqual verify that the return value of the auth operation is correct
+// AuthEqual verify that the return value of the auth operation is correct
 func (es *ExampleSystem) AuthEqual(t *testing.T, password string) {
 	reply, err := redis.String(es.conn.Do("auth", password))
 	assert.NoError(t, err)
 	assert.Equal(t, "OK", reply)
 }
 
-//AuthEqualErr verify that the return value of the auth operation is correct
-func (es *ExampleSystem) AuthEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// AuthEqualErr verify that the return value of the auth operation is correct
+func (es *ExampleSystem) AuthEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := es.conn.Do("auth", args)
 	assert.EqualError(t, err, errValue)
 }
 
-//PingEqual verify that the return value of the ping operation is correct
+// PingEqual verify that the return value of the ping operation is correct
 func (es *ExampleSystem) PingEqual(t *testing.T) {
 	reply, err := redis.String(es.conn.Do("ping", "hello"))
 	assert.NoError(t, err)
@@ -43,8 +43,8 @@ func (es *ExampleSystem) PingEqual(t *testing.T) {
 	assert.Equal(t, "PONG", reply)
 }
 
-//PingEqualErr verify that the return value of the ping operation is correct
-func (es *ExampleSystem) PingEqualErr(t *testing.T, errValue string, args ...interface{}) {
+// PingEqualErr verify that the return value of the ping operation is correct
+func (es *ExampleSystem) PingEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := es.conn.Do("ping", args)
 	assert.EqualError(t, err, errValue)
 }

--- a/tools/autotest/cmd/zset.go
+++ b/tools/autotest/cmd/zset.go
@@ -10,14 +10,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//ExampleList the key command
-//memberScores record the key and value of the operation
+// ExampleList the key command
+// memberScores record the key and value of the operation
 type ExampleZSet struct {
 	memberScores map[string]map[string]float64
 	conn         redis.Conn
 }
 
-//NewExampleList create list object
+// NewExampleList create list object
 func NewExampleZSet(conn redis.Conn) *ExampleZSet {
 	return &ExampleZSet{
 		conn:         conn,
@@ -33,7 +33,7 @@ func (ez *ExampleZSet) ZAddEqual(t *testing.T, key string, values ...string) {
 	}
 	oldLen := len(msmap)
 
-	req := make([]interface{}, 0, len(values))
+	req := make([]any, 0, len(values))
 	req = append(req, key)
 	for i := range values {
 		req = append(req, values[i])
@@ -72,13 +72,13 @@ func (ez *ExampleZSet) ZAddEqual(t *testing.T, key string, values ...string) {
 	assert.Nil(t, err)
 }
 
-func (ez *ExampleZSet) ZAddEqualErr(t *testing.T, errValue string, args ...interface{}) {
+func (ez *ExampleZSet) ZAddEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := ez.conn.Do("zadd", args...)
 	assert.EqualError(t, err, errValue)
 }
 
 func (ez *ExampleZSet) ZRemEqual(t *testing.T, key string, members ...string) {
-	req := make([]interface{}, 0, len(members))
+	req := make([]any, 0, len(members))
 	req = append(req, key)
 	for i := range members {
 		req = append(req, members[i])
@@ -102,7 +102,7 @@ func (ez *ExampleZSet) ZRemEqual(t *testing.T, key string, members ...string) {
 	assert.Nil(t, err)
 }
 
-func (ez *ExampleZSet) ZRemEqualErr(t *testing.T, errValue string, args ...interface{}) {
+func (ez *ExampleZSet) ZRemEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := ez.conn.Do("zrem", args...)
 	assert.EqualError(t, err, errValue)
 }
@@ -160,7 +160,7 @@ func (ez *ExampleZSet) ZRangeEqual(t *testing.T, key string, start int, stop int
 	ez.ZAnyOrderRangeEqual(t, key, start, stop, true, withScore)
 }
 
-func (ez *ExampleZSet) ZRangeEqualErr(t *testing.T, errValue string, args ...interface{}) {
+func (ez *ExampleZSet) ZRangeEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := ez.conn.Do("zrange", args...)
 	assert.EqualError(t, err, errValue)
 }
@@ -169,7 +169,7 @@ func (ez *ExampleZSet) ZRevRangeEqual(t *testing.T, key string, start int, stop 
 	ez.ZAnyOrderRangeEqual(t, key, start, stop, false, withScore)
 }
 
-func (ez *ExampleZSet) ZRevRangeEqualErr(t *testing.T, errValue string, args ...interface{}) {
+func (ez *ExampleZSet) ZRevRangeEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := ez.conn.Do("zrevrange", args...)
 	assert.EqualError(t, err, errValue)
 }
@@ -190,7 +190,7 @@ func (ez *ExampleZSet) ZAnyOrderRangeByScoreEqual(t *testing.T, key string, star
 
 	var reply []string
 	var err error
-	req := make([]interface{}, 0)
+	req := make([]any, 0)
 	req = append(req, key)
 	req = append(req, start)
 	req = append(req, stop)
@@ -215,12 +215,12 @@ func (ez *ExampleZSet) ZAnyOrderRangeByScoreEqual(t *testing.T, key string, star
 	assert.Nil(t, err)
 }
 
-func (ez *ExampleZSet) ZRangeByScoreEqualErr(t *testing.T, errValue string, args ...interface{}) {
+func (ez *ExampleZSet) ZRangeByScoreEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := ez.conn.Do("zrangebyscore", args...)
 	assert.EqualError(t, err, errValue)
 }
 
-func (ez *ExampleZSet) ZRevRangeByScoreEqualErr(t *testing.T, errValue string, args ...interface{}) {
+func (ez *ExampleZSet) ZRevRangeByScoreEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := ez.conn.Do("zrevrangebyscore", args...)
 	assert.EqualError(t, err, errValue)
 }
@@ -231,7 +231,7 @@ func (ez *ExampleZSet) ZCardEqual(t *testing.T, key string) {
 	assert.Nil(t, err)
 }
 
-func (ez *ExampleZSet) ZCardEqualErr(t *testing.T, errValue string, args ...interface{}) {
+func (ez *ExampleZSet) ZCardEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := ez.conn.Do("zcard", args...)
 	assert.EqualError(t, err, errValue)
 }
@@ -257,7 +257,7 @@ func (ez *ExampleZSet) ZScoreEqual(t *testing.T, key string, member string) {
 	assert.Nil(t, err)
 }
 
-func (ez *ExampleZSet) ZScoreEqualErr(t *testing.T, errValue string, args ...interface{}) {
+func (ez *ExampleZSet) ZScoreEqualErr(t *testing.T, errValue string, args ...any) {
 	_, err := ez.conn.Do("zscore", args...)
 	assert.EqualError(t, err, errValue)
 }


### PR DESCRIPTION
Rewrites `interface{}` to `any` using `gofmt`

[_Created by Sourcegraph batch change `christine/Go-upgrade-type`._](https://demo.sourcegraph.com/users/christine/batch-changes/Go-upgrade-type)